### PR TITLE
Handle fresh webexec sessions on reconnect

### DIFF
--- a/src/gate.ts
+++ b/src/gate.ts
@@ -166,6 +166,56 @@ export class Gate {
         return Math.random().toString(16).slice(2) + Math.random().toString(16).slice(2)
     }
 
+    private async applyServerPayload(rawPayload: string | null) {
+        let layout: ServerPayload | null = null
+        try {
+            if (rawPayload)
+                layout = JSON.parse(rawPayload)
+        } catch(e) {
+            layout = null
+        }
+
+        const incomingSession = layout?.session
+        const hadSession = !!this.sessionId
+        let freshSession = false
+        let needsPersist = false
+
+        if (hadSession) {
+            if (!incomingSession || incomingSession !== this.sessionId) {
+                freshSession = true
+                this.sessionId = incomingSession || this.newSessionId()
+                if (layout)
+                    layout.session = this.sessionId
+                else
+                    layout = null
+                this.clear()
+                needsPersist = true
+            }
+        } else {
+            if (incomingSession) {
+                this.sessionId = incomingSession
+            } else {
+                this.sessionId = this.newSessionId()
+                if (layout)
+                    layout.session = this.sessionId
+                needsPersist = true
+            }
+        }
+
+        if (freshSession)
+            this.notify("fresh webexec session")
+
+        this.setLayout(layout)
+
+        if (needsPersist && this.session) {
+            try {
+                await this.session.setPayload(this.dump())
+            } catch(e) {
+                this.t7.log("failed to persist session payload", e)
+            }
+        }
+    }
+
     /*
      * onSessionState(state) is called when the connection
      * state changes.
@@ -190,48 +240,7 @@ export class Gate {
         } else if (state == "failed")  {
             this.handleFailure(failure)
         } else if (state == "gotlayout") {
-            let layout: ServerPayload | null = null
-            try {
-                layout = JSON.parse(this.session.lastPayload)
-            } catch(e) {
-                layout = null
-            }
-
-            const incomingSession = layout?.session
-            const hadSession = !!this.sessionId
-            let freshSession = false
-            let needsPersist = false
-
-            if (hadSession) {
-                if (!incomingSession || incomingSession !== this.sessionId) {
-                    freshSession = true
-                    this.sessionId = incomingSession || this.newSessionId()
-                    if (layout)
-                        layout.session = this.sessionId
-                    else
-                        layout = null
-                    this.clear()
-                    needsPersist = true
-                }
-            } else {
-                if (incomingSession) {
-                    this.sessionId = incomingSession
-                } else {
-                    this.sessionId = this.newSessionId()
-                    if (layout)
-                        layout.session = this.sessionId
-                    needsPersist = true
-                }
-            }
-
-            if (freshSession)
-                this.notify("fresh webexec session")
-
-            this.setLayout(layout)
-
-            if (needsPersist && this.session)
-                this.session.setPayload(this.dump())
-
+            void this.applyServerPayload(this.session?.lastPayload ?? null)
             this.onConnected()
         }
     }
@@ -443,8 +452,8 @@ export class Gate {
                 return
             }
 
-            const finish = layout => {
-                this.setLayout(JSON.parse(layout) as ServerPayload)
+            const finish = async layout => {
+                await this.applyServerPayload(layout)
                 this.reconnectCount = 0
                 resolve()
             }
@@ -932,55 +941,13 @@ export class Gate {
     }
     async load() {
         this.t7.log("loading gate")
-        let layout: ServerPayload | null = null
+        let payload: string | null = null
         try {
-            const payload = await this.session.getPayload()
-            try {
-                layout = JSON.parse(payload)
-            } catch(e) {
-                layout = null
-            }
+            payload = await this.session.getPayload()
         } catch(e) {
             this.t7.log("failed to get payload", e)
-            layout = null
         }
-        console.log("got payload", layout)
-
-        const incomingSession = layout?.session
-        const hadSession = !!this.sessionId
-        let freshSession = false
-        let needsPersist = false
-
-        if (hadSession) {
-            if (!incomingSession || incomingSession !== this.sessionId) {
-                freshSession = true
-                this.sessionId = incomingSession || this.newSessionId()
-                if (layout)
-                    layout.session = this.sessionId
-                else
-                    layout = null
-                this.clear()
-                needsPersist = true
-            }
-        } else {
-            if (incomingSession) {
-                this.sessionId = incomingSession
-            } else {
-                this.sessionId = this.newSessionId()
-                if (layout)
-                    layout.session = this.sessionId
-                needsPersist = true
-            }
-        }
-
-        if (freshSession)
-            this.notify("fresh webexec session")
-
-        this.setLayout(layout)
-
-        if (needsPersist && this.session)
-            this.session.setPayload(this.dump())
-
+        await this.applyServerPayload(payload)
         document.getElementById("map").classList.add("hidden")
     }
     onFormError(err) {

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -163,7 +163,10 @@ export class Gate {
             crypto.getRandomValues(bytes)
             return Array.from(bytes).map(b => b.toString(16).padStart(2, "0")).join("")
         }
-        return Math.random().toString(16).slice(2) + Math.random().toString(16).slice(2)
+        const bytes = []
+        for (let i = 0; i < 16; i++)
+            bytes.push(Math.floor(Math.random() * 256))
+        return bytes.map(b => b.toString(16).padStart(2, "0")).join("")
     }
 
     private async applyServerPayload(rawPayload: string | null) {
@@ -186,8 +189,6 @@ export class Gate {
                 this.sessionId = incomingSession || this.newSessionId()
                 if (layout)
                     layout.session = this.sessionId
-                else
-                    layout = null
                 this.clear()
                 needsPersist = true
             }
@@ -228,8 +229,7 @@ export class Gate {
         this.t7.log(`updating ${this.name} state to ${state} ${failure}`)
         if (state == "connected") {
             this.marker = null
-            this.load()
-            this.onConnected()
+            void this.load().then(() => this.onConnected())
         } else if (state == "disconnected") {
             // TODO: add warn class
             this.lastDisconnect = Date.now()
@@ -240,8 +240,7 @@ export class Gate {
         } else if (state == "failed")  {
             this.handleFailure(failure)
         } else if (state == "gotlayout") {
-            void this.applyServerPayload(this.session?.lastPayload ?? null)
-            this.onConnected()
+            void this.applyServerPayload(this.session?.lastPayload ?? null).then(() => this.onConnected())
         }
     }
     async handleSSHFailure() {

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -190,8 +190,48 @@ export class Gate {
         } else if (state == "failed")  {
             this.handleFailure(failure)
         } else if (state == "gotlayout") {
-            const layout = JSON.parse(this.session.lastPayload)
+            let layout: ServerPayload | null = null
+            try {
+                layout = JSON.parse(this.session.lastPayload)
+            } catch(e) {
+                layout = null
+            }
+
+            const incomingSession = layout?.session
+            const hadSession = !!this.sessionId
+            let freshSession = false
+            let needsPersist = false
+
+            if (hadSession) {
+                if (!incomingSession || incomingSession !== this.sessionId) {
+                    freshSession = true
+                    this.sessionId = incomingSession || this.newSessionId()
+                    if (layout)
+                        layout.session = this.sessionId
+                    else
+                        layout = null
+                    this.clear()
+                    needsPersist = true
+                }
+            } else {
+                if (incomingSession) {
+                    this.sessionId = incomingSession
+                } else {
+                    this.sessionId = this.newSessionId()
+                    if (layout)
+                        layout.session = this.sessionId
+                    needsPersist = true
+                }
+            }
+
+            if (freshSession)
+                this.notify("fresh webexec session")
+
             this.setLayout(layout)
+
+            if (needsPersist && this.session)
+                this.session.setPayload(this.dump())
+
             this.onConnected()
         }
     }
@@ -890,18 +930,57 @@ export class Gate {
         }
         await this.session.connect(this.marker)
     }
-    load() {
+    async load() {
         this.t7.log("loading gate")
-        this.session.getPayload().then((payload: string) => {
-            let layout: ServerPayload | null = null
+        let layout: ServerPayload | null = null
+        try {
+            const payload = await this.session.getPayload()
             try {
                 layout = JSON.parse(payload)
             } catch(e) {
                 layout = null
             }
-            console.log("got payload", layout)
-            this.setLayout(layout)
-        })
+        } catch(e) {
+            this.t7.log("failed to get payload", e)
+            layout = null
+        }
+        console.log("got payload", layout)
+
+        const incomingSession = layout?.session
+        const hadSession = !!this.sessionId
+        let freshSession = false
+        let needsPersist = false
+
+        if (hadSession) {
+            if (!incomingSession || incomingSession !== this.sessionId) {
+                freshSession = true
+                this.sessionId = incomingSession || this.newSessionId()
+                if (layout)
+                    layout.session = this.sessionId
+                else
+                    layout = null
+                this.clear()
+                needsPersist = true
+            }
+        } else {
+            if (incomingSession) {
+                this.sessionId = incomingSession
+            } else {
+                this.sessionId = this.newSessionId()
+                if (layout)
+                    layout.session = this.sessionId
+                needsPersist = true
+            }
+        }
+
+        if (freshSession)
+            this.notify("fresh webexec session")
+
+        this.setLayout(layout)
+
+        if (needsPersist && this.session)
+            this.session.setPayload(this.dump())
+
         document.getElementById("map").classList.add("hidden")
     }
     onFormError(err) {

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -25,6 +25,7 @@ export interface ServerPayload {
     height: number
     width: number
     windows: SerializedWindow[]
+    session?: string
     active?: boolean
 }
 
@@ -32,6 +33,7 @@ export interface ServerPayload {
  * The gate class abstracts a host connection
  */
 export class Gate {
+    sessionId?: string
     activeW: Window
     addr: string
     boarding: boolean
@@ -154,6 +156,16 @@ export class Gate {
             const e = this.e.querySelector(".tabbar-names") as HTMLElement
             e.style.setProperty("--indicator-color", color)
     }
+
+    private newSessionId(): string {
+        if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+            const bytes = new Uint8Array(16)
+            crypto.getRandomValues(bytes)
+            return Array.from(bytes).map(b => b.toString(16).padStart(2, "0")).join("")
+        }
+        return Math.random().toString(16).slice(2) + Math.random().toString(16).slice(2)
+    }
+
     /*
      * onSessionState(state) is called when the connection
      * state changes.
@@ -691,7 +703,8 @@ export class Gate {
         const container = this.e.querySelector(".windows-container") as HTMLDivElement
         return { windows: windows,
                  width: container.clientWidth,
-                 height: container.clientHeight }
+                 height: container.clientHeight,
+                 session: this.sessionId }
     }
     storeState() {
         /* TODO: restore the restore to last state


### PR DESCRIPTION
Implements session hash on payload and clears stale client state after server reset.

- adds session to payload and generates one if missing
- on reconnect/load, clears local layout when session mismatches and notifies user
- persists new session back to server payload

Fixes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session tracking with unique session IDs and inclusion of session info in saved state.
  * Centralized server payload processing for consistent application of incoming state.

* **Bug Fixes / Improvements**
  * More reliable session persistence and restoration, safer handling of incoming vs. existing sessions, automatic session creation when missing, and improved error handling during async state load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->