### PR TITLE
Fix stale webexec session restore

### DIFF
--- a/src/gate.ts
+++ b/src/gate.ts
@@ -23,6 +23,7 @@ const TOOLBAR_HEIGHT = 93
 
 export interface ServerPayload {
     height: number
+    session?: string
     width: number
     windows: SerializedWindow[]
     active?: boolean
@@ -62,6 +63,7 @@ export class Gate {
     sshPort: number
     reconnectCount: number
     lastState: ServerPayload
+    sessionHash?: string
     wasSSH: boolean | undefined
     constructor (props) {
         // given properties
@@ -178,8 +180,8 @@ export class Gate {
         } else if (state == "failed")  {
             this.handleFailure(failure)
         } else if (state == "gotlayout") {
-            const layout = JSON.parse(this.session.lastPayload)
-            this.setLayout(layout)
+            const layout = this.parseServerPayload(this.session.lastPayload)
+            this.applyServerState(layout, this.isFreshWebexecSession(layout))
             this.onConnected()
         }
     }
@@ -392,13 +394,26 @@ export class Gate {
             }
 
             const finish = layout => {
-                this.setLayout(JSON.parse(layout) as ServerPayload)
+                const state = this.parseServerPayload(layout)
+                this.applyServerState(state, this.isFreshWebexecSession(state))
                 this.reconnectCount = 0
                 resolve()
             }
+            const checkSessionAndRestore = (layout) => {
+                const state = this.parseServerPayload(layout)
+                if (this.isFreshWebexecSession(state)) {
+                    this.applyServerState(state, true)
+                    this.reconnectCount = 0
+                    resolve()
+                    return
+                }
+                if (this.marker != null)
+                    return this.session.reconnect(this.marker).then(finish)
+                finish(layout)
+            }
             if (!isNative) {
-                this.session.reconnect(this.marker)
-                .then(layout => finish(layout))
+                this.session.reconnect(null)
+                .then(checkSessionAndRestore)
                 .catch(e  => {
                     if (this.session) {
                         this.wasSSH = this.session.isSSH
@@ -420,8 +435,19 @@ export class Gate {
                 reject(e)
             }
             this.t7.readId().then(({publicKey, privateKey}) => {
-                this.session.reconnect(this.marker, publicKey, privateKey)
-                .then(finish)
+                this.session.reconnect(null, publicKey, privateKey)
+                .then(layout => {
+                    const state = this.parseServerPayload(layout as string)
+                    if (this.isFreshWebexecSession(state)) {
+                        this.applyServerState(state, true)
+                        this.reconnectCount = 0
+                        resolve()
+                        return
+                    }
+                    if (this.marker != null)
+                        return this.session.reconnect(this.marker, publicKey, privateKey).then(finish)
+                    finish(layout as string)
+                })
                 .catch(e => {
                     if (this.session != session)
                         // session changed, ignore the failure
@@ -522,6 +548,45 @@ export class Gate {
         message = `\x1B[4m${prefix}\x1B[0m: ${message}`
         this.t7.notify(message, dontShow)
     }
+    newSessionHash(): string {
+        return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+    }
+    ensureSessionHash(): string {
+        if (!this.sessionHash)
+            this.sessionHash = this.newSessionHash()
+        return this.sessionHash
+    }
+    parseServerPayload(payload: string | ServerPayload | null | undefined): ServerPayload | null {
+        if (!payload)
+            return null
+        if (typeof payload != "string")
+            return payload
+        try {
+            return JSON.parse(payload) as ServerPayload
+        } catch(e) {
+            return null
+        }
+    }
+    isFreshWebexecSession(state: ServerPayload | null): boolean {
+        if (!state?.session)
+            return true
+        return !!this.sessionHash && state.session != this.sessionHash
+    }
+    applyServerState(state: ServerPayload | null, fresh = false) {
+        if (fresh) {
+            this.clear()
+            this.marker = null
+            this.sessionHash = state?.session || this.newSessionHash()
+            if (state)
+                state.session = this.sessionHash
+            this.notify("fresh webexec session")
+        } else if (state?.session) {
+            this.sessionHash = state.session
+        } else if (!this.sessionHash) {
+            this.sessionHash = this.newSessionHash()
+        }
+        this.setLayout(state)
+    }
     /*
      * returns an array of panes
      */
@@ -539,6 +604,10 @@ export class Gate {
     }
     setLayout(state: ServerPayload | null = null) {
         terminal7.log("in setLayout", state)
+        if (state?.session)
+            this.sessionHash = state.session
+        else
+            this.ensureSessionHash()
         this.lastState = state
         const winLen = this.windows.length
         if ((state == null) || !(state.windows instanceof Array) || (state.windows.length == 0)) {
@@ -690,6 +759,7 @@ export class Gate {
         })
         const container = this.e.querySelector(".windows-container") as HTMLDivElement
         return { windows: windows,
+                 session: this.ensureSessionHash(),
                  width: container.clientWidth,
                  height: container.clientHeight }
     }
@@ -819,7 +889,7 @@ export class Gate {
                 case "set_payload":
                     const layout = msg.args["payload"]
                     this.fitScreen = (container.clientWidth == layout.width) && (container.clientHeight == layout.height)
-                    this.setLayout(layout)
+                    this.applyServerState(layout, this.isFreshWebexecSession(layout))
                     break
                 case "get_clipboard":
                     Clipboard.read().then(cb => {
@@ -880,14 +950,9 @@ export class Gate {
     load() {
         this.t7.log("loading gate")
         this.session.getPayload().then((payload: string) => {
-            let layout: ServerPayload | null = null
-            try {
-                layout = JSON.parse(payload)
-            } catch(e) {
-                layout = null
-            }
+            const layout = this.parseServerPayload(payload)
             console.log("got payload", layout)
-            this.setLayout(layout)
+            this.applyServerState(layout, this.isFreshWebexecSession(layout))
         })
         document.getElementById("map").classList.add("hidden")
     }

--- a/tests/gate.test.ts
+++ b/tests/gate.test.ts
@@ -95,11 +95,52 @@ describe("gate", () => {
         expect(w.rootLayout.cells[1].xoff).to.equal(0.5)
         expect(w.activeP.xoff).to.equal(0.5)
         let d = h.dump()
+        expect(d.session.length).toBeGreaterThan(0)
         expect(d.windows.length).to.equal(2)
         expect(d.windows[0].layout.dir).to.equal("topbottom")
         expect(d.windows[0].layout.cells.length).to.equal(2)
         expect(d.windows[0].layout.cells[0].yoff).to.equal(0.2)
         expect(d.windows[0].layout.cells[1].yoff).to.equal(0.5)
+    })
+    it("starts fresh when the server payload has no session", async () => {
+        const oldState = {
+            session: "old-session",
+            width: 100,
+            height: 100,
+            windows: [{
+                name: "old",
+                active: true,
+                layout: {
+                    dir: "topbottom",
+                    sx: 1,
+                    sy: 1,
+                    xoff: 0,
+                    yoff: 0,
+                    cells: [{
+                        sx: 1,
+                        sy: 1,
+                        xoff: 0,
+                        yoff: 0,
+                        active: true,
+                    }],
+                },
+            }],
+        }
+        const serverState = {
+            width: 100,
+            height: 100,
+            windows: [],
+        }
+        let h = t.addGate()
+        h.open(e)
+        h.applyServerState(oldState)
+        expect(h.dump().session).to.equal("old-session")
+
+        h.applyServerState(serverState, h.isFreshWebexecSession(serverState))
+
+        expect(h.windows.length).to.equal(1)
+        expect(h.dump().session).not.to.equal("old-session")
+        expect(t.map.t0.out).toContain("fresh webexec session")
     })
     it("can create a gate", async () => {
         let addHost = document.getElementById("add-host")


### PR DESCRIPTION
Closes #117.

## Summary
- add a session identifier to the persisted server payload
- check the server payload before restoring a marked reconnect
- clear stale local layout state and notify the user when a fresh webexec session is detected

## Tests
- yarn lint
- yarn vitest run tests/gate.test.ts

Note: `yarn vitest run tests/termina7.test.ts` fails on upstream/master as well because the existing PreferencesWeb test setup throws `this.impl.setItem is not a function`; this PR does not touch that path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session tracking with automatic session identification to preserve application state across reconnections

* **Improvements**
  * Enhanced fresh session detection to intelligently distinguish between new connections and reconnection attempts, improving connection stability and state restoration

* **Refactor**
  * Centralized server payload handling with unified parsing and state application logic for more consistent behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tuzig/terminal7/pull/503)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->