### PR TITLE
Handle fresh webexec sessions on reconnect

### DIFF
--- a/aatp/http_webrtc/http_webrtc.spec.ts
+++ b/aatp/http_webrtc/http_webrtc.spec.ts
@@ -116,6 +116,31 @@ pinch_max_y_velocity = 0.1`
         expect(exitState).toEqual("success")
         await expect(page.locator('.pane')).toHaveCount(1)
     })
+    test('stale server session starts fresh instead of restoring old panes', async() => {
+        const sessionState = await page.evaluate(async() => {
+            const gate = window.terminal7.activeG,
+                  staleSession = gate.sessionId
+            gate.fitScreen = false
+            if (gate.sendStateTask != null) {
+                clearTimeout(gate.sendStateTask)
+                gate.sendStateTask = null
+            }
+            await gate.session.setPayload({windows: [], width: 1280, height: 627})
+            gate.marker = 123
+            await gate.reconnect()
+            const payload = JSON.parse(await gate.session.getPayload())
+            return {
+                marker: gate.marker,
+                oldSession: staleSession,
+                payloadSession: payload.session,
+                sessionId: gate.sessionId,
+            }
+        })
+        await expect(page.locator('.pane')).toHaveCount(1)
+        expect(sessionState.marker).toBeNull()
+        expect(sessionState.sessionId).not.toEqual(sessionState.oldSession)
+        expect(sessionState.payloadSession).toEqual(sessionState.sessionId)
+    })
     test('disengage and reconnect', async() => {
 
         await reloadPage(page)

--- a/src/__mocks__/webrtc_session.ts
+++ b/src/__mocks__/webrtc_session.ts
@@ -1,5 +1,5 @@
 import { Failure } from "../session"
-import { Session, Channel, State, CallbackType } from "../session.ts"
+import { Session, Channel, State, CallbackType, ChannelID } from "../session.ts"
 
 const returnLater = (ret: unknown) => 
     vi.fn(() => new Promise( resolve => setTimeout(() => resolve(ret), 0)))
@@ -20,6 +20,7 @@ export class HTTPWebRTCSession implements Session {
     onStateChange: (state: State) => void
     onCMD: (payload: string) => void
     static fail = false
+    static payload: string | null = null
     constructor(address: string, username: string, password: string, port?=22) {
         console.log("New seesion", address, username, password, port)
     }
@@ -38,9 +39,14 @@ export class HTTPWebRTCSession implements Session {
         })
     )
     close = returnLater(undefined)
-    getPayload = returnLater(null)
-    setPayload = returnLater(null)
+    getPayload = vi.fn(() => Promise.resolve(HTTPWebRTCSession.payload))
+    setPayload = vi.fn(payload => {
+        HTTPWebRTCSession.payload = typeof payload == "string" ? payload : JSON.stringify(payload)
+        return Promise.resolve(HTTPWebRTCSession.payload)
+    })
+    reconnect = vi.fn(() => Promise.resolve(HTTPWebRTCSession.payload))
     disconnect = returnLater(null)
+    isOpen = vi.fn(() => true)
     public get isSSH() {
         return false
     }

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -169,7 +169,7 @@ export class Gate {
         return bytes.map(b => b.toString(16).padStart(2, "0")).join("")
     }
 
-    private async applyServerPayload(rawPayload: string | null) {
+    private parseServerPayload(rawPayload: string | null): ServerPayload | null {
         let layout: ServerPayload | null = null
         try {
             if (rawPayload)
@@ -177,7 +177,11 @@ export class Gate {
         } catch(e) {
             layout = null
         }
+        return layout
+    }
 
+    private async applyServerPayload(rawPayload: string | null): Promise<boolean> {
+        const layout = this.parseServerPayload(rawPayload)
         const incomingSession = layout?.session
         const hadSession = !!this.sessionId
         let freshSession = false
@@ -215,6 +219,24 @@ export class Gate {
                 this.t7.log("failed to persist session payload", e)
             }
         }
+        return freshSession
+    }
+
+    private async shouldRestoreSession(session: Session, publicKey?: string, privateKey?: string): Promise<boolean> {
+        if (session.isSSH)
+            return true
+
+        const payload = session.isOpen() ?
+              await session.getPayload() :
+              await session.reconnect(null, publicKey, privateKey)
+        const freshSession = await this.applyServerPayload(
+            typeof payload == "string" ? payload : null)
+        if (!freshSession)
+            return true
+
+        this.marker = null
+        this.reconnectCount = 0
+        return false
     }
 
     /*
@@ -452,20 +474,31 @@ export class Gate {
             }
 
             const finish = async layout => {
-                await this.applyServerPayload(layout)
+                await this.applyServerPayload(typeof layout == "string" ? layout : null)
                 this.reconnectCount = 0
                 resolve()
             }
             if (!isNative) {
-                this.session.reconnect(this.marker)
-                .then(layout => finish(layout))
-                .catch(e  => {
-                    if (this.session) {
-                        this.wasSSH = this.session.isSSH
-                        this.session.close()
-                        this.session = null
+                this.shouldRestoreSession(session)
+                .then(restore => {
+                    if (!restore) {
+                        resolve()
+                        return
                     }
-                    terminal7.log("reconnect failed:", e)
+                    session.reconnect(this.marker)
+                    .then(layout => finish(layout))
+                    .catch(e  => {
+                        if (this.session) {
+                            this.wasSSH = this.session.isSSH
+                            this.session.close()
+                            this.session = null
+                        }
+                        terminal7.log("reconnect failed:", e)
+                        reject(e)
+                    })
+                })
+                .catch(e  => {
+                    terminal7.log("reconnect session check failed:", e)
                     reject(e)
                 })
                 return
@@ -480,15 +513,23 @@ export class Gate {
                 reject(e)
             }
             this.t7.readId().then(({publicKey, privateKey}) => {
-                this.session.reconnect(this.marker, publicKey, privateKey)
-                .then(finish)
-                .catch(e => {
-                    if (this.session != session)
-                        // session changed, ignore the failure
+                this.shouldRestoreSession(session, publicKey, privateKey)
+                .then(restore => {
+                    if (!restore) {
+                        resolve()
                         return
-                    console.log("session reconnect failed", e)
-                    this.reconnect().then(resolve).catch(reject)
+                    }
+                    session.reconnect(this.marker, publicKey, privateKey)
+                    .then(finish)
+                    .catch(e => {
+                        if (this.session != session)
+                            // session changed, ignore the failure
+                            return
+                        console.log("session reconnect failed", e)
+                        this.reconnect().then(resolve).catch(reject)
+                    })
                 })
+                .catch(closeSessionAndDisconnect)
             }).catch(e => {
                 this.t7.log("failed to read id", e)
                 closeSessionAndDisconnect(e)

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -488,6 +488,9 @@ export class Gate {
                     session.reconnect(this.marker)
                     .then(layout => finish(layout))
                     .catch(e  => {
+                        if (this.session != session)
+                            // session changed, ignore the failure
+                            return
                         if (this.session) {
                             this.wasSSH = this.session.isSSH
                             this.session.close()

--- a/src/ssh_session.ts
+++ b/src/ssh_session.ts
@@ -350,4 +350,7 @@ export class HybridSession extends SSHSession {
     public get isSSH() {
         return !this.webrtcSession 
     }
+    isOpen(): boolean {
+        return this.webrtcSession?.isOpen() || false
+    }
 }

--- a/tests/gate.test.ts
+++ b/tests/gate.test.ts
@@ -130,7 +130,7 @@ describe("gate", () => {
         expect(panes[0].d.resize).toHaveBeenCalledTimes(0)
     })
     it("stores a session hash on first empty webexec payload", async () => {
-        let g = t.addGate()
+        const g = t.addGate()
         g.open(e)
         await g.connect()
         await sleep(100)
@@ -141,7 +141,7 @@ describe("gate", () => {
     it("starts fresh when the webexec session hash changes before marker restore", async () => {
         t.map.t0.out = ""
         HTTPWebRTCSession.payload = JSON.stringify({session: "new", windows: [], width: 1280, height: 627})
-        let g = t.addGate()
+        const g = t.addGate()
         g.open(e)
         g.session = new HTTPWebRTCSession("http://example.com:7777/offer", "", "")
         g.sessionId = "old"
@@ -159,7 +159,7 @@ describe("gate", () => {
     it("starts fresh when the webexec payload is missing a session hash", async () => {
         t.map.t0.out = ""
         HTTPWebRTCSession.payload = JSON.stringify({windows: [], width: 1280, height: 627})
-        let g = t.addGate()
+        const g = t.addGate()
         g.open(e)
         g.session = new HTTPWebRTCSession("http://example.com:7777/offer", "", "")
         g.sessionId = "old"

--- a/tests/gate.test.ts
+++ b/tests/gate.test.ts
@@ -30,6 +30,8 @@ describe("gate", () => {
         t.clearTimeouts()
         t.gates = new Array()
         t.pendingPanes = {}
+        HTTPWebRTCSession.fail = false
+        HTTPWebRTCSession.payload = null
     })
     it("starts with no gates", () => {
         expect(t.gates.length).to.equal(0)
@@ -126,6 +128,50 @@ describe("gate", () => {
         expect(panes[0].t).not.toBeNull()
         expect(panes[0].d).not.toBeNull()
         expect(panes[0].d.resize).toHaveBeenCalledTimes(0)
+    })
+    it("stores a session hash on first empty webexec payload", async () => {
+        let g = t.addGate()
+        g.open(e)
+        await g.connect()
+        await sleep(100)
+        const stored = JSON.parse(HTTPWebRTCSession.payload)
+        expect(stored.session).toEqual(expect.any(String))
+        expect(g.dump().session).toEqual(stored.session)
+    })
+    it("starts fresh when the webexec session hash changes before marker restore", async () => {
+        t.map.t0.out = ""
+        HTTPWebRTCSession.payload = JSON.stringify({session: "new", windows: [], width: 1280, height: 627})
+        let g = t.addGate()
+        g.open(e)
+        g.session = new HTTPWebRTCSession("http://example.com:7777/offer", "", "")
+        g.sessionId = "old"
+        g.marker = 123
+
+        await g.reconnect()
+
+        expect(g.session.getPayload).toHaveBeenCalledTimes(1)
+        expect(g.session.reconnect).not.toHaveBeenCalled()
+        expect(g.marker).toBeNull()
+        expect(g.dump().session).toEqual("new")
+        expect(g.panes().length).toEqual(1)
+        expect(t.map.t0.out).toContain("fresh webexec session")
+    })
+    it("starts fresh when the webexec payload is missing a session hash", async () => {
+        t.map.t0.out = ""
+        HTTPWebRTCSession.payload = JSON.stringify({windows: [], width: 1280, height: 627})
+        let g = t.addGate()
+        g.open(e)
+        g.session = new HTTPWebRTCSession("http://example.com:7777/offer", "", "")
+        g.sessionId = "old"
+        g.marker = 123
+
+        await g.reconnect()
+
+        expect(g.session.getPayload).toHaveBeenCalledTimes(1)
+        expect(g.session.reconnect).not.toHaveBeenCalled()
+        expect(g.marker).toBeNull()
+        expect(g.dump().session).not.toEqual("old")
+        expect(t.map.t0.out).toContain("fresh webexec session")
     })
 	it("remembers username", async () => {
 		let g = t.addGate({name:"foo", addr: "foo", username: "eyal"})


### PR DESCRIPTION
Fixes #117.

This adds a persisted `session` hash to webexec payloads and checks the server payload before restoring old panes on reconnect. If the server payload has a different or missing session, Terminal7 clears the stale local marker/layout, applies the server state, persists a fresh session hash when needed, and notifies the user with `fresh webexec session`.

Key details:
- generates and stores a session hash on first empty webexec payload
- includes the session hash in `Gate.dump()` so state saves keep it
- preflights `get_payload` before calling restore with an old marker
- bypasses the preflight for plain SSH sessions and delegates hybrid session openness to the WebRTC session
- adds unit coverage plus a real `http_webrtc` acceptance test for stale server state

Verification:
- `corepack yarn lint`
- `corepack yarn vitest run` (52 passed, 1 skipped)
- `corepack yarn build`
- `docker compose -f aatp/http_webrtc/lab.yaml -f /tmp/terminal7-crlf-override.yaml --project-directory . up --exit-code-from runner` (10 passed, 1 skipped)

Note: the temporary compose override only normalizes CRLF in the Windows checkout before running the existing lab scripts; the tested app and webexec flow are otherwise the repository lab.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#117: Improve handling of reseted hosts](https://oss.issuehunt.io/repos/256925027/issues/117)
---
</details>
<!-- /Issuehunt content-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of stale server sessions—they now reconnect with fresh state instead of attempting to restore invalid sessions.

* **Tests**
  * Added comprehensive test coverage for session reconnection and restoration scenarios to ensure proper recovery from stale sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tuzig/terminal7/pull/504)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->